### PR TITLE
Improve error messages + fixes on typing expressions

### DIFF
--- a/examples/automata.sg
+++ b/examples/automata.sg
@@ -1,15 +1,10 @@
 binary =
-	-b($e) $ok;
-	-b($0:X) +b(X);
-	-b($1:X) +b(X).
-
-checker = galaxy
-	interaction: ({tested} {test})[+i=>+b].
-	expect: $ok.
-end
+	-i($e) $ok;
+	-i($0:X) +i(X);
+	-i($1:X) +i(X).
 
 'input words
-e :: binary [checker]
+e :: binary.
 e = +i($e).
 
 000 :: binary [checker]

--- a/examples/binary4.sg
+++ b/examples/binary4.sg
@@ -9,10 +9,10 @@ checker = galaxy
 	expect: $ok.
 end
 
-b1 :: u4 [checker]
+b1 :: u4 [checker].
 b1 = $b($1 $1); $b($2 $0); $b($3 $0); $b($4 $1).
 
-b1 :: u4 [checker]
+b1 :: u4 [checker].
 b2 = $b($1 $0); $b($2 $0); $b($3 $1); $b($4 $1).
 
 and =

--- a/examples/linear_lambda.sg
+++ b/examples/linear_lambda.sg
@@ -40,5 +40,5 @@ end
 
 adapter = -id($l:X) +x(X); -id($r:X) +y(X).
 
-'vehicle :: "a -o a" [checker]
+'vehicle :: "a -o a" [checker].
 vehicle = id_func adapter.

--- a/examples/mll.sg
+++ b/examples/mll.sg
@@ -17,7 +17,7 @@ checker = galaxy
 	expect: $c5(X19) $c6(X19).
 end
 
-id :: "a -o a" [checker]
+id :: "a -o a" [checker].
 id =
 	-5($l:X) +1(X);
 	-5($r:X) +2(X);

--- a/examples/naive_nat.sg
+++ b/examples/naive_nat.sg
@@ -14,16 +14,16 @@ end
 	+nat(X) $arg;
 	-nat(X) $out.
 
-0 :: nat [checker]
+0 :: nat [checker].
 0 = +nat($0).
 
-1 :: nat [checker]
+1 :: nat [checker].
 1 = +nat($s($0)).
 
-2 :: nat [checker]
+2 :: nat [checker].
 2 = +nat($s($s($0))).
 
-add1 :: "nat -> nat" [fchecker]
+add1 :: "nat -> nat" [fchecker].
 add1 = -nat(X) +nat($s(X)).
 
 is_empty =

--- a/examples/stack.sg
+++ b/examples/stack.sg
@@ -3,13 +3,17 @@ print process
 	'push 1 then 0
 	-stack0(X) +stack1($1:X).
 	-stack1(X) +stack2($0:X).
+
 	'pop & save
 	-stack2(C:X) +stack3(X) +save(C).
+
 	'conditional duplication
 	-stack3($0:X) +stack4($0:$0:X);
 	-stack3($1:X) +stack4($1:$1:X).
+
 	'freeze information
 	-stack4(X) $stack(X).
+
 	-save(C) $save(C).
 	'clean remaining polarized stars
 	clean.

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -52,8 +52,8 @@ nat = galaxy
 		-nat($s(N)) +nat(N).
 end
 
-0 :: nat [checker]
+0 :: nat [checker].
 0 = +nat($0).
 
-1 :: nat [checker]
+1 :: nat [checker].
 1 = +nat($s($0)).

--- a/guide/src/typing.md
+++ b/guide/src/typing.md
@@ -46,14 +46,34 @@ nat =
   -nat($s(N)) +nat(N).
 ```
 
-On peut ensuite écrire des assertions de typage de la forme `x :: t [c]` où
+On peut ensuite écrire des assertions de typage de la forme `x :: t [c].` où
 `x` est l'élément testé, `t` est le type (définissant des tests) et `c` et le
 checker.
 
 ```
-0 :: nat [checker]
+0 :: nat [checker].
 0 = +nat($0).
 
-1 :: nat [checker]
+1 :: nat [checker].
+1 = +nat($s($0)).
+```
+
+On peut aussi omettre de préciser le checker. Dans ce cas, le checker par
+défaut est :
+
+```
+checker = galaxy
+  interaction: {tested} {test}.
+  expect: $ok.
+end
+```
+
+Cela nous permet d'écrire :
+
+```
+0 :: nat.
+0 = +nat($0).
+
+1 :: nat.
 1 = +nat($s($0)).
 ```

--- a/src/lsc/unification.ml
+++ b/src/lsc/unification.ml
@@ -100,7 +100,7 @@ let extract_idfuncs ts =
 
 let signals = ref []
 
-(* FIXME: does work as expected *)
+(* FIXME: doesn't work as expected *)
 let emit_signals sub =
   let new_signals = List.map ~f:(fun (_, t) -> t) sub in
   signals := new_signals @ !signals

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -26,28 +26,36 @@ and galaxy_expr =
   | Token of string
   | Clean
 
+exception IllFormedChecker
+exception UnknownField of ident
+exception UnknownID of ident
+exception EmptyProcess
+exception MisplacedClean
+exception TestFailed of ident * ident * ident * galaxy * galaxy
+
 type env = {
   objs  : (ident * galaxy_expr) list;
   types : (ident * (ident * ident option)) list;
 }
 
+let empty_env = { objs = []; types = [] }
+
 type declaration =
   | Def of ident * galaxy_expr
   | ShowGalaxy of galaxy_expr
   | PrintGalaxy of galaxy_expr
-  | SetOption of ident * bool
   | TypeDef of ident * ident * ident option
 
 type program = declaration list
 
-let showsteps = ref false
-let showtrace = ref false
-let cleaner = ref false
-
 let add_obj env x e = List.Assoc.add ~equal:equal_string env.objs x e
-let get_obj env x = List.Assoc.find_exn ~equal:equal_string env.objs x
+let get_obj env x =
+  try List.Assoc.find_exn ~equal:equal_string env.objs x
+  with Not_found_s(_) -> raise (UnknownID x)
 let add_type env x e = List.Assoc.add ~equal:equal_string env.types x e
-let get_type env x = List.Assoc.find_exn ~equal:equal_string env.types x
+let get_type env x =
+  try List.Assoc.find_exn ~equal:equal_string env.types x
+  with Not_found_s(_) -> raise (UnknownID x)
 
 let rec map_galaxy env ~f = function
   | Const mcs -> Const (f mcs)
@@ -57,8 +65,7 @@ let rec map_galaxy env ~f = function
 and map_galaxy_expr env ~f = function
   | Raw g -> Raw (map_galaxy env ~f:f g)
   | Access (e, x) -> Access (map_galaxy_expr env ~f:f e, x)
-  | Id x -> get_obj env x
-    |> map_galaxy_expr env ~f:f
+  | Id x -> get_obj env x |> map_galaxy_expr env ~f:f
   | Exec e -> Exec (map_galaxy_expr env ~f:f e)
   | Union (e, e') ->
     Union (map_galaxy_expr env ~f:f e, map_galaxy_expr env ~f:f e')
@@ -105,16 +112,18 @@ let rec eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
   | Token _ -> Const []
   | Access (e, x) ->
     begin match eval_galaxy_expr env e with
-    | Const _ -> failwith "Can't access field of a constellation."
+    | Const _ -> raise (UnknownField x)
     | Galaxy g ->
-      List.Assoc.find_exn ~equal:equal_string g x
-      |> eval_galaxy_expr env
+      try
+        List.Assoc.find_exn ~equal:equal_string g x
+        |> eval_galaxy_expr env
+      with Not_found_s(_) -> raise (UnknownField x)
     end
   | Id x ->
     begin try
       get_obj env x |> eval_galaxy_expr env
     with Sexplib0__Sexp.Not_found_s _ ->
-      failwith ("Error: undefined identifier " ^ x ^ ".");
+      raise (UnknownID x)
     end
   | Union (e, e') ->
     let mcs1 = eval_galaxy_expr env e  |> galaxy_to_constellation env in
@@ -123,8 +132,7 @@ let rec eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
   | Exec e  ->
     Const (eval_galaxy_expr env e
     |> galaxy_to_constellation env
-    |> exec ~showtrace:!showtrace ~showsteps:!showsteps
-    |> (if !cleaner then concealing else Fn.id)
+    |> exec ~showtrace:false ~showsteps:false
     |> unmark_all)
   | Extend (pf, e) ->
     Const (eval_galaxy_expr env e
@@ -142,7 +150,7 @@ let rec eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
     Const (eval_galaxy_expr env e
     |> galaxy_to_constellation env
     |> remove_mark_all |> focus)
-  | Process [] -> failwith "ExprError: empty stellar sequence."
+  | Process [] -> Const []
   | Process (h::t) ->
     let init = eval_galaxy_expr env h
       |> galaxy_to_constellation env
@@ -159,7 +167,7 @@ let rec eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
         eval_galaxy_expr env (Exec (Union (x, Raw (Const origin))))
         |> galaxy_to_constellation env
     ))
-  | Clean -> failwith "'Clean' special cannot occur outside stellar sequences."
+  | Clean -> raise MisplacedClean
   | SubstVar (x, r, e) ->
     subst_vars env (x, None) r e
     |> eval_galaxy_expr env
@@ -175,43 +183,78 @@ and galaxy_to_constellation env = function
   | Galaxy g -> List.fold_left g ~init:[] ~f:(fun acc (_, v) ->
     galaxy_to_constellation env (eval_galaxy_expr env v) @ acc)
 
+
+let string_of_runtime_err e =
+  let red text = "\x1b[31m" ^ text ^ "\x1b[0m" in
+  match e with
+  | UnknownField x ->
+    Printf.sprintf "%s: field '%s' not found.\n"
+    (red "UnknownField Error") x
+  | UnknownID x ->
+    Printf.sprintf "%s: identifier '%s' not found.\n"
+    (red "UnknownID Error") x
+  | MisplacedClean ->
+    Printf.sprintf "%s: 'clean' constant cannot occur here.\n"
+    (red "MisplacedClean Error")
+  | TestFailed (x, t, id, got, expected) ->
+    Printf.sprintf "%s: %s.\nChecking %s :: %s\n* got: %s;\n* expected: %s\n"
+    (red "TestFailed Error")
+    (if equal_string id "_"
+      then ("unique test of '" ^ t ^ "' failed")
+      else ("test '" ^ id ^ "' failed"))
+    x t
+    (got
+      |> galaxy_to_constellation empty_env
+      |> List.map ~f:remove_mark
+      |> string_of_constellation)
+    (expected
+      |> galaxy_to_constellation empty_env
+      |> List.map ~f:remove_mark
+      |> string_of_constellation)
+  | _ -> raise e
+
 let equal_galaxy env g g' =
   let mcs  = galaxy_to_constellation env g  in
   let mcs' = galaxy_to_constellation env g' in
   Lsc_ast.equal_mconstellation mcs mcs'
 
-let typecheck env x t (ck : ident option) : unit =
-  let echecker = match ck with
-    | None -> Union (Token "tested", Token "test")
-    | Some xck -> get_obj env xck
-  in
+let typecheck env x t (ck : galaxy_expr) : unit =
   let gtests = match get_obj env t |> eval_galaxy_expr env with
     | Const mcs -> [("_", Raw (Const mcs))]
     | Galaxy gtests -> gtests
   in
-  let gchecker =
-    match echecker |> eval_galaxy_expr env with
-    | Const _ -> failwith "Ill-formed checker."
-    | Galaxy g -> g
-  in
-  let testing = List.map gtests ~f:(fun (_, test) ->
-    Exec (SubstGal ("tested", get_obj env x,
-        SubstGal ("test", test,
-            List.Assoc.find_exn ~equal:equal_string gchecker "interaction")))
-    |> eval_galaxy_expr env
-  ) in
-  let expect =
-    List.Assoc.find_exn ~equal:equal_string gchecker "expect"
-    |> eval_galaxy_expr env
-  in
-  if List.exists testing ~f:(fun r -> not (equal_galaxy env r expect)) then
-    failwith ("TypeError: " ^ x ^ " not of type " ^ t ^ ".")
+  let testing = List.map gtests ~f:(fun (idtest, test) -> match ck with
+    | Raw (Galaxy gck) ->
+      let format_field = "interaction" in
+      let format =
+        try List.Assoc.find_exn ~equal:equal_string gck format_field
+        with Not_found_s(_) -> raise (UnknownField format_field)
+      in
+        idtest,
+          Exec (SubstGal ("tested", get_obj env x,
+            SubstGal ("test", test, format)
+          ))
+        |> eval_galaxy_expr env
+    | _weak73 -> raise IllFormedChecker
+    ) in
+  let expect = Access (ck, "expect") |> eval_galaxy_expr env in
+  List.iter testing ~f:(fun (idtest, got) ->
+    if not (equal_galaxy env got expect) then
+    raise (TestFailed (x, t, idtest, got, expect))
+  )
+
+let default_checker =
+  Raw (Galaxy [
+    ("interaction", Union (Token "tested", Token "test"));
+    ("expect", Raw (Const [Unmarked [func "ok" []]]))
+  ])
 
 let eval_decl env : declaration -> env = function
   | Def (x, e) ->
     let env = { objs = add_obj env x e; types = env.types } in
     begin match List.Assoc.find ~equal:equal_string env.types x with
-    | Some (t, ck) -> (typecheck env x t ck; env)
+    | Some (t, None) -> (typecheck env x t default_checker; env)
+    | Some (t, Some xck) -> (typecheck env x t (get_obj env xck); env)
     | None -> env
     end
   | ShowGalaxy e ->
@@ -230,19 +273,15 @@ let eval_decl env : declaration -> env = function
     |> Stdlib.print_string;
     Stdlib.print_newline ();
     env
-  | SetOption (id, b) ->
-    begin
-      if (equal_string id "show-steps") then (showsteps := b)
-      else if (equal_string id "show-trace") then (showtrace := b)
-      else if (equal_string id "cleaner") then (cleaner := b)
-      else failwith ("OptionEror: unrecognized option '" ^ id ^ "'.")
-    end;
-    env
   | TypeDef (x, t, ck) ->
     { objs = env.objs; types = add_type env x (t, ck) }
 
 let eval_program p =
-  let empty_env = { objs = []; types = [] } in
-  List.fold_left
-  ~f:(fun acc x -> eval_decl acc x)
-  ~init:empty_env p
+  try
+    List.fold_left
+    ~f:(fun acc x -> eval_decl acc x)
+    ~init:empty_env p
+  with e -> string_of_runtime_err e
+    |> Out_channel.output_string Out_channel.stdout;
+    Out_channel.flush Out_channel.stdout;
+    empty_env

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -17,9 +17,7 @@ rule read = parse
   | "show"    { SHOW }
   | "galaxy"  { GALAXY }
   | "print"   { PRINT }
-  | "set"     { SET }
   | "process" { PROCESS }
-  | "unset"   { UNSET }
   | "->"      { RARROW }
   | "=>"      { DRARROW }
   | "."       { DOT }

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -7,7 +7,6 @@ open Sgen_ast
 %token CLEAN
 %token PROCESS
 %token GALAXY
-%token SET UNSET
 %token RARROW DRARROW
 %token EQ
 %token DOT
@@ -29,17 +28,14 @@ declaration:
   { ShowGalaxy e }
 | PRINT; EOL*; e=galaxy_expr;
   { PrintGalaxy e }
-| SET; x=SYM
-  { SetOption (x, true) }
-| UNSET; x=SYM
-  { SetOption (x, false) }
-| x=SYM; CONS; CONS; t=SYM; EOL*; ck=checker_def?;
+| x=SYM; CONS; CONS; t=SYM; EOL*; ck=checker_def; DOT;
   { TypeDef (x, t, ck) }
-| x=SYM; CONS; CONS; t=SYM; EOL*; LBRACK; RBRACK; EOL;
+| x=SYM; CONS; CONS; t=SYM; DOT;
   { TypeDef (x, t, None) }
 
 checker_def:
-| LBRACK; x=SYM; RBRACK; { x }
+| LBRACK; x=SYM; RBRACK; { Some x }
+| LBRACK; RBRACK;        { None }
 
 galaxy_expr:
 | gc=galaxy_content; DOT; { gc }
@@ -78,6 +74,7 @@ galaxy_item:
 | x=SYM; CONS; EOL*; gb=galaxy_block; END; EOL*;  { (x, gb) }
 
 galaxy_block:
+| PROCESS; EOL*; { Process [] }
 | PROCESS; EOL*; l=process_item+; { Process l }
 
 process_item:


### PR DESCRIPTION
- Fix syntax of typing expression `x :: t` (dot `.` required at the end)
- Fixes error messages (and add error message for failed tests with "got" and "expected" values)

Closes #22 
Closes #12 