### PR TITLE
Handle process constants as identifiers, add kill, rename clean

### DIFF
--- a/bin/lscrun.ml
+++ b/bin/lscrun.ml
@@ -38,7 +38,7 @@ let () =
          ~showsteps:!showsteps mcs in
   if not !showsteps && not !showtrace then
     result
-    |> (if !unfincomp then concealing else Fn.id)
+    |> (if !unfincomp then kill else Fn.id)
     |> string_of_constellation
     |> Stdlib.print_endline
   else output_string stdout "No interaction left.\n"

--- a/examples/automata.sg
+++ b/examples/automata.sg
@@ -7,13 +7,13 @@ binary =
 e :: binary.
 e = +i($e).
 
-000 :: binary [checker]
+000 :: binary.
 000 = +i($0:$0:$0:$e).
 
-010 :: binary [checker]
+010 :: binary.
 010 = +i($0:$1:$0:$e).
 
-110 :: binary [checker]
+110 :: binary.
 110 = +i($1:$1:$0:$e).
 
 a1 = galaxy
@@ -28,7 +28,7 @@ a1 = galaxy
 		-a($0:W $q1) +a(W $q2).
 end
 
-show process e.   a1. clean. end
-show process 000. a1. clean. end
-show process 010. a1. clean. end
-show process 110. a1. clean. end
+show process e.   a1. kill. end
+show process 000. a1. kill. end
+show process 010. a1. kill. end
+show process 110. a1. kill. end

--- a/examples/binary4.sg
+++ b/examples/binary4.sg
@@ -27,5 +27,5 @@ print process
 	and[$arg=>$3].
 	and[$arg=>$4].
 	b2[$b=>+b2].
-	clean.
+	kill.
 end

--- a/examples/circuits.sg
+++ b/examples/circuits.sg
@@ -21,7 +21,7 @@ print process
 	'output
 		-c4(R) R.
 		semantics.
-		'clean.
+		'kill.
 end
 
 print process
@@ -37,5 +37,5 @@ print process
 		-c4(R) R.
 	'apply semantics
 		semantics.
-		'clean.
+		'kill.
 end

--- a/examples/prolog.sg
+++ b/examples/prolog.sg
@@ -23,5 +23,5 @@ query =
 print process
 	query.
 	graph composition.
-	clean.
+	kill.
 end

--- a/examples/stack.sg
+++ b/examples/stack.sg
@@ -15,6 +15,6 @@ print process
 	-stack4(X) $stack(X).
 
 	-save(C) $save(C).
-	'clean remaining polarized stars
-	clean.
+	'kill remaining polarized stars
+	kill.
 end

--- a/guide/src/definitions.md
+++ b/guide/src/definitions.md
@@ -130,7 +130,7 @@ représentation d'état (mémoire par exemple).
 chez Boris Eng ou de "proof-trace" chez Pablo Donato. Les processus-preuves
 construisent des objet-preuves (constellations).
 
-# Nettoyage
+# Arrêt de processus
 
 Dans le résultat d'une exécution, si l'on représente les résultats par des
 rayons à polarité nulle, alors les étoiles contenant des rayons polarisés
@@ -138,7 +138,7 @@ peuvent être interprétés comme des calculs non terminés qu'il pourrait être
 effacés.
 
 Pour cela, dans les processus de constructions, nous pouvons utiliser
-l'expression spéciale `clean` :
+l'expression spéciale `kill` :
 
 ```
 c = process
@@ -146,7 +146,7 @@ c = process
   -n0(X) +n1($s(X)).
   -n1(X) +n2($s(X)).
   -n2(X) $result(X); -n2(X) +n3(X).
-  clean.
+  kill.
 end
 
 print c.
@@ -155,4 +155,17 @@ print c.
 Nous avons utilisé un rayon `+n3(X)` pour poursuivre des calculs
 si nous souhaitons. Le résultat est stocké dans `$result(X)`.
 Mais si nous souhaitons seulement conserver le résultat et retirer toute
-autre possibilité de calcul alors on peut utiliser `clean`.
+autre possibilité de calcul alors on peut utiliser `kill`.
+
+# Nettoyage de processus
+
+Il arrive parfois que l'on se retrouve avec des étoiles vides `[]` dans
+les processus. Il est possible de s'en débarrasser avec la commande `clean` :
+
+```
+print process
+  +f($0).
+  -f(X).
+  clean.
+end
+```

--- a/src/lsc/lsc_ast.ml
+++ b/src/lsc/lsc_ast.ml
@@ -213,7 +213,8 @@ let extract_intspace (mcs : marked_constellation) =
    --------------------------------------- *)
 
 let unpolarized_star = List.for_all ~f:(Fn.compose not is_polarised)
-let concealing = List.filter ~f:unpolarized_star
+let kill = List.filter ~f:unpolarized_star
+let clean = List.filter ~f:List.is_empty
 
 let pairs_with_rest l =
   let rec aux acc = function

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -12,7 +12,6 @@ rule read = parse
   (* Stellogen *)
   | '{'       { LBRACE }
   | '}'       { RBRACE }
-  | "clean"   { CLEAN }
   | "end"     { END }
   | "show"    { SHOW }
   | "galaxy"  { GALAXY }

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -4,7 +4,6 @@ open Sgen_ast
 
 %token LBRACE RBRACE
 %token SHOW PRINT
-%token CLEAN
 %token PROCESS
 %token GALAXY
 %token RARROW DRARROW
@@ -79,4 +78,3 @@ galaxy_block:
 
 process_item:
 | e=galaxy_content; DOT; EOL*; { e }
-| CLEAN; DOT; EOL*; { Clean }

--- a/test/test.ml
+++ b/test/test.ml
@@ -12,7 +12,7 @@ let test filename expected () =
   let result =
     exec ~showtrace:false
          ~showsteps:false mcs
-         |> concealing
+         |> kill
          |> string_of_constellation in
   check string "same string" result expected
 


### PR DESCRIPTION
- old `clean` is renamed into `kill` (kill process)
- new `clean` constant to remove empty stars
- handle reserved words for definitions

Closes #25.