### PR TITLE
Change terminology (introduce action and state space)

### DIFF
--- a/guide/en/src/stellarresolution/execution.md
+++ b/guide/en/src/stellarresolution/execution.md
@@ -41,30 +41,38 @@ ray `X`. The result is `X{X:=a}`, i.e., `a`.
 
 ## Execution
 
-Execution is somewhat akin to solving a puzzle. You start with a constellation made up of several stars. Choose some *initial stars*, then create copies of other stars to interact with them through fusion. The process continues until no further interactions are possible (saturation). The final constellation is the result of the execution.
+<<<<<<< Updated upstream
+Execution is somewhat akin to solving a puzzle or playing darts. You start with
+a constellation made up of several stars. Choose some *initial stars*, then
+create copies of other stars to interact with them through fusion. The process
+continues until no further interactions are possible (saturation). The final
+constellation is the result of the execution.
 
 Formally, the constellation is split into two parts for execution:
-- the set of *initial stars* (serving as a workspace or interaction space);
-the rest, referred to as *reference stars*.
+- the *state space*, corresponding to stars which will be targets for
+interaction;
+- the *action space*, corresponding to stars which will interact with stars of
+the state space.
 
-This separation can be represented as follows, with reference stars on the left and initial stars on the right, separated by the symbol `|-`:
+This separation can be represented as follows, with the action space on the left
+and state space on the right, separated by the symbol `|-`:
 
 ```
-s1 ... sn |- s1' ... sm'
+a1 ... an |- s1 ... sm
 ```
 
 Execution proceeds as follows:
-1. Select a ray `r'` from an initial star `s'`;
-2. Find all possible connections with rays `r` from reference stars `s`;
-3. Duplicate `s'` on the right for each such ray `r` found;
-4. Replace each copy of `s'` with the fusion of `s` and `s'`;
-5. Repeat until no further interactions are possible in the space of initial
+1. Select a ray `r` from a state star `s`;
+2. Find all possible connections with rays `r'` from action stars `s`;
+3. Duplicate `s` on the right for each such ray `r'` found;
+4. Replace each copy of `s` with the fusion of `a` and `s`;
+5. Repeat until no further interactions are possible in the state space.
 stars.
 
 ## Example
 
 Consider the execution of the following constellation, where the only initial
-star is prefixed by `@`:
+state star is prefixed by `@`:
 
 ```
 +add($0 Y Y);
@@ -100,7 +108,8 @@ Select the first ray
 ```
 
 `+add($0 Y Y)` cannot interact with `-add($s($s($0)) $s($s($0)) R)`
-because the first argument `$0` is incompatible with `$s($s($0))`. However, it can interact with `+add($s(X) Y $s(Z))`. Fusing:
+because the first argument `$0` is incompatible with `$s($s($0))`. However, it
+can interact with `+add($s(X) Y $s(Z))`. Fusing:
 
 ```
 -add(X Y Z) +add($s(X) Y $s(Z))
@@ -155,7 +164,7 @@ Selecting the first ray once more
 >>-add($0 $s($s($0)) Z')<< $s($s(Z'))
 ```
 
-This ray interacts only with the first reference star `+add($0 Y Y)`, resulting
+This ray interacts only with the first action star `+add($0 Y Y)`, resulting
 in:
 
 ```

--- a/guide/en/src/stellogen/definitions.md
+++ b/guide/en/src/stellogen/definitions.md
@@ -58,18 +58,7 @@ print +a; -a $b.
 
 ## Focus
 
-If we wish for stars to be initial, they have to be prefixed with the symbol
-`@` (focus):
-
-```
-x = @+a; -a $b.
-z = @-f(X).
-```
-
-Initial stars are put in a work space and are subject to fusion interaction
-with copies of the other stars.
-
-We can also focus all stars of a constellation by prefixing it with `@`:
+We can focus all stars of a constellation by prefixing it with `@`:
 
 ```
 x = +a; -a $b.
@@ -89,8 +78,9 @@ c = process
 end
 ```
 
-This chain starts with the first constellation `+n0($0)`, considered to be 
-initial*. The next constellation then interacts with the previous one. Thus we
+This chain starts with the first constellation `+n0($0)` as a state space. The
+next constellation then interacts as an action space with the previous one 
+seen as a state space). Thus we
 have an interaction chain with a complete focus on the previous result.
 
 It's as if we did the following computation:

--- a/guide/fr/src/stellarresolution/execution.md
+++ b/guide/fr/src/stellarresolution/execution.md
@@ -43,8 +43,9 @@ propagée aux rayons adjacents.
 
 ## Exécution
 
-Cela marche à peu près comme pour la résolution d'un puzzle. Vous avez une
-constellation faites de plusieurs étoiles. Choisissez des *étoiles initiales*
+Cela marche à peu près comme pour la résolution d'un puzzle ou un jeu de
+fléchettes. Vous avez une constellation faites de plusieurs étoiles.
+Choisissez des *étoiles initiales*
 puis des copies des autres étoiles seront jetées dessus pour interagir par
 fusion. L'opération continue jusqu'à qu'il n'y ait plus d'interactions
 possibles (saturation).
@@ -52,30 +53,30 @@ La constellation obtenue à la fin est le résultat de l'exécution.
 
 Plus formellement, nous séparons une constellation en deux parties pour
 l'exécuter :
-- l'ensemble des *étoiles initiales* (à voir comme une sorte d'espace de
-travail ou d'interaction);
-- le reste appelé *étoiles de référence*.
+- *l'espace d'états*, un espace d'étoiles qui seront cibles de l'interaction;
+- *l'espace d'actions* qui sont des étoiles qui vont interagir avec
+les étoiles de l'espace d'états.
 
-On pourrait représenter cette séparation ainsi avec les étoiles de référence
-à gauche et les étoiles initiales à droite, séparées avec le symbole `|-` :
+On pourrait représenter cette séparation ainsi avec l'espace d'actions
+à gauche et l'espace d'états à droite, séparées avec le symbole `|-` :
 
 ```
-s1 ... sn |- s1' ... sm'
+a1 ... an |- s1 ... sm
 ```
 
 L'exécution procède de la façon suivante :
-1. selectionner un rayon `r'` d'une étoile initiale `s'`;
-2. chercher toutes les connexions possibles avec des rayons `r` d'étoiles de
-   référence `s`;
-3. dupliquer `s'` à droite pour chaque tel rayon `r` trouvé;
-4. remplacer chaque copie de `s'` par la fusion `s` entre et `s'`;
-5. répéter jusqu'à qu'il n'y a plus aucune interaction possible l'espace des
-   étoiles initiales.
+1. selectionner un rayon `r` d'une étoile d'état `s`;
+2. chercher toutes les connexions possibles avec des rayons `r'` d'étoiles
+d'action `a`;
+3. dupliquer `s` à droite pour chaque tel rayon `r'` trouvé car il y a
+plusieurs interactions possibles à satisfaire;
+4. remplacer chaque copie de `s` par la fusion entre `a` et `s`;
+5. répéter jusqu'à qu'il n'y a plus aucune interaction possible l'espace d'états.
 
 ## Exemple
 
 Considérons l'exécution de la constellation suivante où l'unique étoile
-initiale est préfixée par `@`:
+initiale de l'espace d'état est préfixée par `@`:
 ```
 +add($0 Y Y);
 -add(X Y Z) +add($s(X) Y $s(Z));
@@ -167,7 +168,7 @@ Nous sélectionnons le premier rayon :
 >>-add($0 $s($s($0)) Z')<< $s($s(Z'))
 ```
 
-Il ne peut interagir qu'avec la première étoile de référence `+add($0 Y Y)`, ce
+Il ne peut interagir qu'avec la première étoile d'action `+add($0 Y Y)`, ce
 qui nous donne :
 
 ```

--- a/guide/fr/src/stellogen/definitions.md
+++ b/guide/fr/src/stellogen/definitions.md
@@ -60,18 +60,7 @@ print +a; -a $b.
 
 ## Focus
 
-Si on souhaite que des étoiles soient initiales, il faut les préfixer avec le
-symbole `@` (focus) :
-
-```
-x = @+a; -a $b.
-z = @-f(X).
-```
-
-Les étoiles initiales sont placées dans un espace de travail et sont sujettes
-à l'interaction par fusion avec des copies des autres étoiles.
-
-On peut aussi mettre le focus sur toutes les étoiles d'une constellation en
+On peut mettre le focus sur toutes les étoiles d'une constellation en
 la préfixant aussi avec `@` :
 
 ```


### PR DESCRIPTION
I wasn't satisfied with the terminology of reference and initial stars. I now use "action space" (bullets/darts) and "state space" (targets).