### PR TITLE
Add missing test dependency on alcotest

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (name tsyntax)
  (synopsis "Technical interpretation of Girard's transcendental syntax")
  (description "The transcendental syntax provides a low-level language called stellar resolution used to build higher-level abstractions defining types, formulas, proofs and any other logical concepts.")
- (depends base menhir)
+ (depends base menhir (alcotest :with-test))
  (tags
   ("transcendental syntax" "logic programming" "constraint programming" "resolution logic" "unification" "self-assembly")))
 

--- a/tsyntax.opam
+++ b/tsyntax.opam
@@ -21,6 +21,7 @@ depends: [
   "dune" {>= "3.7"}
   "base"
   "menhir"
+  "alcotest" {with-test}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I hit this when trying to do my first build after installing the declared
dependencies using an opam switch creation.